### PR TITLE
Burn LGO when redemption completed

### DIFF
--- a/src/bridge/BridgeController.sol
+++ b/src/bridge/BridgeController.sol
@@ -33,6 +33,8 @@ contract BridgeController is BaseBridgeController {
 
      function burnLGO(uint256 _batchId) external onlyOwner {
         require(!batchLGOBurned[_batchId], "Burned");
+        (,,,bool _isFinalized) = lgoRedemption.snapshots(_batchId);
+        require(_isFinalized, "!Finalized");
         uint256 _amountLGO = lgoRedemption.totalRedemptionAllChain(_batchId) - lgoRedemption.totalRedemptionByChain(_batchId, 56);
         if(_amountLGO > 0) {
             batchLGOBurned[_batchId] = true;

--- a/src/bridge/BridgeController.sol
+++ b/src/bridge/BridgeController.sol
@@ -5,11 +5,15 @@ pragma solidity 0.8.18;
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 import {BaseBridgeController} from "./BaseBridgeController.sol";
-
+import "../interfaces/ILGORedemption.sol";
+import "../interfaces/IERC20Burnable.sol";
 /// @notice BridgeController on the original chain. Bridged token will be locked in this contract
 /// and release once token is send back to original chain.
 contract BridgeController is BaseBridgeController {
     using SafeERC20 for IERC20;
+
+    mapping(uint256 batchId => bool burned) public batchLGOBurned;
+    ILGORedemption public lgoRedemption = ILGORedemption(0x6A5607CeAeE3F947fb5736753F7722D7Fb69eE4F);
 
     constructor() {
         _disableInitializers();
@@ -26,4 +30,17 @@ contract BridgeController is BaseBridgeController {
     function _releaseTokens(address _to, uint256 _amount) internal override {
         IERC20(token).safeTransfer(_to, _amount);
     }
+
+     function burnLGO(uint256 _batchId) external onlyOwner {
+        require(!batchLGOBurned[_batchId], "Burned");
+        uint256 _amountLGO = lgoRedemption.totalRedemptionAllChain(_batchId) - lgoRedemption.totalRedemptionByChain(_batchId, 56);
+        if(_amountLGO > 0) {
+            batchLGOBurned[_batchId] = true;
+            IERC20Burnable(address(token)).burn(_amountLGO);
+            emit LGOBurned(_batchId, _amountLGO);
+        }
+    }
+
+    /*============ EVENTS ===============*/
+    event LGOBurned(uint256 _batchId, uint256 _amount);
 }

--- a/src/interfaces/ILGORedemption.sol
+++ b/src/interfaces/ILGORedemption.sol
@@ -5,4 +5,9 @@ interface ILGORedemption {
     function totalRedemptionAllChain(uint256 _batchId) external returns (uint256);
 
     function totalRedemptionByChain(uint256 _batchId, uint256 _chainId) external returns (uint256);
+
+    function snapshots(uint256 _batchId)
+        external
+        returns (uint256 _startTimestamp, uint256 _endTimestamp, uint256 _lgoSupply, bool _isFinalized);
+    // batchId => snapshot info
 }

--- a/src/interfaces/ILGORedemption.sol
+++ b/src/interfaces/ILGORedemption.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.18;
+
+interface ILGORedemption {
+    function totalRedemptionAllChain(uint256 _batchId) external returns (uint256);
+
+    function totalRedemptionByChain(uint256 _batchId, uint256 _chainId) external returns (uint256);
+}


### PR DESCRIPTION
This function only exists on base chain (BNB), then LGO can be permanent burned once redemption finalized